### PR TITLE
Potential fix for code scanning alert no. 4: Flask app is run in debug mode

### DIFF
--- a/Web/app.py
+++ b/Web/app.py
@@ -745,4 +745,5 @@ def stop_container(container_id):
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    debug_mode = os.getenv("FLASK_DEBUG", "false").lower() == "true"
+    app.run(host="0.0.0.0", port=5000, debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/guan4tou2/Lnadlse/security/code-scanning/4](https://github.com/guan4tou2/Lnadlse/security/code-scanning/4)

To fix the issue, we will remove the hardcoded `debug=True` from the `app.run` call and instead control the debug mode using an environment variable. This approach ensures that debug mode can be enabled for development but remains disabled in production by default. Specifically:
1. Use the `os.getenv` function to read a `FLASK_DEBUG` environment variable.
2. Convert the value of `FLASK_DEBUG` to a boolean and pass it to the `debug` parameter of `app.run`.
3. Update the `app.run` call to use this dynamic configuration.

This change will ensure that the application does not inadvertently run in debug mode in production environments.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
